### PR TITLE
Added link of Python Developer Roadmap

### DIFF
--- a/README.md
+++ b/README.md
@@ -278,6 +278,7 @@
 
 ## 30 | What to do Now?
 - Discussions on how to process further with this knowledge.
+- [Python Developer Roadmap](https://roadmap.sh/python) Complete guide to Python Development.
 
 
 


### PR DESCRIPTION
Hi @hemansnation,

I came across your repository [Python-Roadmap](https://github.com/hemansnation/Python-Roadmap) and found it to be a valuable resource for Python enthusiasts.

While browsing through the repository, I noticed that it was missing links to any structured guides such as the famous ["Python Developer Roadmap"](https://roadmap.sh/python). I took the initiative to submit a ["Pull Request"](https://github.com/hemansnation/Python-Roadmap/pull/1) adding it in "What to do Now?" section.

Thank you for your time and effort in maintaining this valuable resource :)

Best,
Mouaaz